### PR TITLE
Fix CameraBound vs map orientation

### DIFF
--- a/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/QuadTreeTileProvider.cs
+++ b/sdkproject/Assets/Mapbox/Unity/Map/TileProviders/QuadTreeTileProvider.cs
@@ -48,7 +48,11 @@ namespace Mapbox.Unity.Map.TileProviders
 				_cbtpOptions.camera = Camera.main;
 			}
 			_cbtpOptions.camera.transform.hasChanged = false;
-			_groundPlane = new Plane(Vector3.up, 0);
+			_groundPlane = new Plane(
+				_map.GeoToWorldPosition(_map.CenterLatitudeLongitude, false),
+				_map.GeoToWorldPosition(_map.CenterLatitudeLongitude + new Vector2d(0, 1), false),
+				_map.GeoToWorldPosition(_map.CenterLatitudeLongitude + new Vector2d(1, 0), false)
+			);
 			_shouldUpdate = true;
 			_currentExtent.activeTiles = new HashSet<UnwrappedTileId>();
 		}


### PR DESCRIPTION
Right now the camera-bounded tile provider sets the groundplane as `new Plane(Vector3.up, 0)`, regardless of the actual orientation of the map object. This can be fixed by instead defining the plane by taking three arbitrary points on the map and finding their corresponding point in Unity space, and using these points to define the ground plane.

**Related issue**

Example: Closes #832. Relates to #832.

**Description of changes**

Your text here!

**QA checklists**

- [ ] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [ ] **Add tests for new/changed/updated classes and methods!!!**
- [ ] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [ ] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [ ] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [ ] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
